### PR TITLE
feat: add entry option to plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,8 +19,9 @@ class CrxLoadScriptWebpackPlugin {
           .tap('CrxLoadScriptWebpackPlugin', (chunk, set) => {
             if(this.options.entry.test(chunk.name)){
               compilation.addRuntimeModule(chunk, new LoadScriptRuntimeModule());
+              return true;
             }
-            return true;
+            return undefined;
           });
       }
     );

--- a/index.js
+++ b/index.js
@@ -1,6 +1,14 @@
 const LoadScriptRuntimeModule = require('./lib/LoadScriptRuntimeModule');
 
 class CrxLoadScriptWebpackPlugin {
+  /**
+   * 
+   * @param { {entry: RegExp} } options 
+   */
+  constructor(options){
+    if(!(options.entry instanceof RegExp || options.entry.constructor === RegExp))throw Error("The entry option has to be a RegExp")
+    this.options = options
+  }
   apply(compiler) {
     compiler.hooks.compilation.tap(
       'CrxLoadScriptWebpackPlugin',
@@ -9,7 +17,9 @@ class CrxLoadScriptWebpackPlugin {
         compilation.hooks.runtimeRequirementInTree
           .for(RuntimeGlobals.loadScript)
           .tap('CrxLoadScriptWebpackPlugin', (chunk, set) => {
-            compilation.addRuntimeModule(chunk, new LoadScriptRuntimeModule());
+            if(this.options.entry.test(chunk.name)){
+              compilation.addRuntimeModule(chunk, new LoadScriptRuntimeModule());
+            }
             return true;
           });
       }


### PR DESCRIPTION
This PR adds an option `entry` to the webpack plugin. It specifies which entry parts should have their `loadScript` altered.

### Usage
```js
...
entry: {
	contents: "./something/here.js",
	background: "./other/thing.js"
}
...
plugins: [
	new CrxLoadScriptWebpackPlugin({ entry: /contents/ })
]
...
```

The config above will make sure that the new loadScript functions for only `contents` entrypoint.

Resolves #3 